### PR TITLE
Fix typo for doc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ theme: clean
 ```
 
 ## Document
-You can learn how to use this theme by view full document [here](https://blog/lusw.dev/posts/hexo/theme-clean-doc.html).
+You can learn how to use this theme by view full document [here](https://blog.lusw.dev/posts/hexo/theme-clean-doc.html).
 
 ## Creator
 This theme was created by [Blackrock Digital](https://github.com/BlackrockDigital), adapted for Hexo by [Jonathan Klughertz](http://www.codeblocq.com/) and modfy by [LuSkywalker](https://lusw.dev/)


### PR DESCRIPTION
Small typo found for documentation link.

Thank you for adding to the original theme and making it better ❤️ 